### PR TITLE
Updated Dockerfile to use ubuntu 16.04

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,9 +1,14 @@
-FROM ubuntu:14.04.4
+FROM ubuntu:16.04
 MAINTAINER clewis@iqt.org
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install -y git npm nodejs openjdk-7-jre
+# hack for installing openjdk-7-jre refrenced from http://askubuntu.com/questions/759451/how-can-i-install-openjdk-on-ubuntu-16-04
+RUN apt-get update && \
+    apt-get install -y git npm nodejs software-properties-common && \
+    add-apt-repository ppa:openjdk-r/ppa && \
+    apt-get update && \
+    apt-get install -y openjdk-7-jre
 RUN ln -s /usr/bin/nodejs /usr/local/bin/node
 
 RUN git clone https://github.com/swagger-api/swagger-ui.git


### PR DESCRIPTION
There was an error installing openjdk-7-jre, so using
a hack as mentioned in comment

Might I also suggest that 873.2 MB is a huge size for a Docker image, try using a slim image(If available) 
@cglewis 
#33
