### PR TITLE
Basic integration test for listing providers

### DIFF
--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -1,4 +1,5 @@
 from vcontrol.rest.commands import info
+# from vcontrol.rest.providers import list_all
 
 import requests
 
@@ -8,3 +9,11 @@ def test_info_command_r():
     assert r.text == 'unable to get info on foo'
     c_inst = info.InfoCommandR()
     c_inst.GET("foo")
+
+
+
+def test_providers_list_all():
+    """ tests the ListProvidersR class """
+    r = requests.get('http://localhost:8080/v1/providers/list')
+    assert r.status_code == 200
+    assert r.json() == {}


### PR DESCRIPTION
So I did a basic integration tests that checks for 200 and an empty dict (since none was in the filesystem). Not sure if that is what you were looking for. LMK

As a note, it may be a good idea to create more unit tests instead of integration tests. That way you have more control over checking individual functionality of the code (and an ability to mock out 3rd party of out of scope functions). I haven't used pytest before so I will have to see if I can mock, and create a request factory to go that route. 
